### PR TITLE
Actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,9 +8,16 @@ updates:
       interval: daily
       time: "00:00"
       timezone: "Etc/UTC"
+    assignees:
+      - "fredclausen"
+      - "mikenye"
+      - "kx1t"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    assignees:
+      - "fredclausen"
+      - "mikenye"

--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -458,7 +458,7 @@ jobs:
 
   deploy_wreadsb:
     name: Deploy wreadsb to ghcr.io
-    needs: [deploy_ghcr_base]
+    needs: [deploy_ghcr_rtlsdr]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -732,7 +732,7 @@ jobs:
   deploy_wreadsb:
     name: Test deploy wreadsb to ghcr.io
     # Define any dependant steps
-    needs: [deploy_ghcr_base]
+    needs: [deploy_ghcr_rtlsdr]
     # Define dockerfile and image tag
     env:
       DOCKERFILE: Dockerfile.wreadsb


### PR DESCRIPTION
* Add assignees by default with Dependabot. All three of us for any Docker container updates, and @fredclausen  and @mikenye for GitHub Actions. I left @kx1t off for the actions since he hasn't really been involved with that, but, can also add him in too. Doesn't matter, just wanted to keep email spam down :)
* `wreadsb` was dependent on `base` originally and now needs `rtlsdr`