### PR TITLE
Remove Legacy S6

### DIFF
--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -118,7 +118,7 @@ jobs:
       # Get changed files
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
 
       # Log into ghcr (so we can push images)
       - name: Login to ghcr.io

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -53,7 +53,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         with:
           files: |
             Dockerfile.base
@@ -124,7 +124,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles below the ${{ env.DOCKERFILE }} entry, one per line
         with:
           files: |
@@ -132,7 +132,7 @@ jobs:
             Dockerfile.base
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -213,7 +213,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles below the ${{ env.DOCKERFILE }} entry, one per line
         with:
           files: |
@@ -221,7 +221,7 @@ jobs:
             Dockerfile.base
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -304,7 +304,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles below the ${{ env.DOCKERFILE }} entry, one per line
         with:
           files: |
@@ -312,7 +312,7 @@ jobs:
             Dockerfile.base
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -395,7 +395,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles below the ${{ env.DOCKERFILE }} entry, one per line
         with:
           files: |
@@ -404,7 +404,7 @@ jobs:
             Dockerfile.rtlsdr
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -488,7 +488,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles below the ${{ env.DOCKERFILE }} entry, one per line
         with:
           files: |
@@ -497,7 +497,7 @@ jobs:
             Dockerfile.rtlsdr
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -581,7 +581,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles below the ${{ env.DOCKERFILE }} entry, one per line
         with:
           files: |
@@ -590,7 +590,7 @@ jobs:
             Dockerfile.rtlsdr
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -674,7 +674,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         with:
           files: |
             Dockerfile.dump978-full
@@ -683,7 +683,7 @@ jobs:
             Dockerfile.soapyrtlsdr
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -768,14 +768,14 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         with:
           files: |
             Dockerfile.wreadsb
             Dockerfile.base
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |
@@ -858,7 +858,7 @@ jobs:
       # List of files to check to trigger a rebuild on this job
       - name: Get specific changed files
         id: changed-files-specific
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles below the ${{ env.DOCKERFILE }} entry, one per line
         with:
           files: |
@@ -866,7 +866,7 @@ jobs:
             Dockerfile.base
       - name: Get changed status of parent
         id: changed-files-parent
-        uses: tj-actions/changed-files@v38.1.0
+        uses: tj-actions/changed-files@v38.1.3
         # Add dependent dockerfiles, one per line
         with:
           files: |


### PR DESCRIPTION
Remove legacy S6

## Misc Tasks
- [ ] Update S6 install script to remove symlinks and extra tarballs

## Containers

### ACARS

- [ ] acarsdec
- [ ] ACARS Hub
- [ ] acars router
- [ ] dumpvdl2
- [ ] vdlm2dec

### ADSB

- [ ] airspy
- [ ] adsb exchange
- [ ] adsb hub
- [ ] beast splitter
- [ ] dump978
- [ ] fr24
- [ ] opensky
- [ ] piaware
- [ ] planefinder
- [ ] radarbox
- [ ] radar virtuel
- [ ] readsb
- [ ] tar1090
- [ ] ultra feeder

### Others

- [ ] Plane Fence
- [ ] RWP
- [ ] rtlsdrairband
- [ ] Ship Alert
- [ ] Vessel Alert