### PR TITLE
wiedehopf readsb: disable arm rtl-sdr zerocopy workaround

### DIFF
--- a/Dockerfile.wreadsb
+++ b/Dockerfile.wreadsb
@@ -38,6 +38,7 @@ RUN set -x && \
   make \
   RTLSDR=yes \
   AIRCRAFT_HASH_BITS=14 \
+  DISABLE_RTLSDR_ZEROCOPY_WORKAROUND=yes \
   -j "$(nproc)" \
   && \
   find "/src/readsb" -maxdepth 1 -executable -type f -exec cp -v {} /usr/local/bin/ \; && \


### PR DESCRIPTION
sdr-e rtl-sdr baseimage is compiled without zerocopy thus the zerocopy workaround is not needed

on a pi3 this will save 3% CPU in the USB thread which could slightly improve MLAT stability
saving CPU is always good and this workaround is only needed when librtlsdr is compiled with zerocopy