### PR TITLE
Update usage instructions for Dockerfile.mlatclient

### DIFF
--- a/Dockerfile.mlatclient
+++ b/Dockerfile.mlatclient
@@ -5,14 +5,14 @@
 # 1. Create a downloader image like this:
 # FROM ghcr.io/sdr-enthusiasts/docker-baseimage:mlat-client as downloader
 #
-# 2. In your target image, make sure to add this to the APT install list:
-# KEPT_PACKAGES+=(python3-setuptools) && \
+# 2. In your target image, start your RUN command like this:
+# RUN --mount=type=bind,from=downloader,source=/,target=/downloader set -x && \
 #
-# 3. Copy the following files into your target container:
-# COPY --from=downloader /mlatclient.tgz /mlatclient.tgz
+# 3. In your target image in that same RUN command, make sure to add this to the APT install list:
+# KEPT_PACKAGES+=(python3-pkg-resources) && \
 #
-# 4. In a RUN directive for the target image, and after copying /mlatclient.tgz, do this:
-# tar zxf /mlatclient.tgz -C / && rm -f /mlatclient.tgz && \
+# 4. Also in the same RUN command for your target image, do this:
+# tar zxf /downloader/mlatclient.tgz -C / && \
 # ----------------------------------------------------------------------------------------
 FROM debian:bookworm-20240513-slim
 

--- a/Dockerfile.mlatclient
+++ b/Dockerfile.mlatclient
@@ -18,10 +18,10 @@ FROM debian:bookworm-20240513-slim
 
 ENV MLATCLIENT_REPO="https://github.com/wiedehopf/mlat-client.git"
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-x", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008,SC2086,DL3003
-RUN set -x && \
+RUN \
   PACKAGES=() && \
   # packages needed to install
   PACKAGES+=(git) && \


### PR DESCRIPTION
Updated instructions to use image mounts instead of COPY commands. This has as advantage that the mlat-client can be deployed without creating an extra layer, reducing the overall image size