### PR TITLE
dump978-full: add python3

### DIFF
--- a/Dockerfile.dump978-full
+++ b/Dockerfile.dump978-full
@@ -21,6 +21,9 @@ RUN set -x && \
     TEMP_PACKAGES+=(libboost-regex1.74-dev) && \
     KEPT_PACKAGES+=(libboost-filesystem1.74.0) && \
     TEMP_PACKAGES+=(libboost-filesystem1.74-dev) && \
+    # this baseimage is used by docker-piaware and docker-dump978
+    # piaware needs python for mlat-client, dump978 for autogain, install it in this baseimage
+    KEPT_PACKAGES+=(python3) && \
     # install packages
     apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
this baseimage is used by docker-piaware and docker-dump978 which both need python

install it here to avoid data duplication

this can go with the next other merge.
right now both those images have python in their own install.
doubling apt install python3 is not an issue if the container based on this one is built close in time to the base image as their will be nothing extra installed.