### PR TITLE
install python3-minimal in base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,6 +47,8 @@ RUN \
   KEPT_PACKAGES+=(nano) && \
   KEPT_PACKAGES+=(iputils-ping) && \
   KEPT_PACKAGES+=(dnsutils) && \
+  # used by enough images to warrant installing it in common (adds 17 MB to image size)
+  KEPT_PACKAGES+=(python3-minimal) && \
   # install packages
   ## Builder fixes...
   mkdir -p /usr/sbin/ && \

--- a/Dockerfile.wreadsb
+++ b/Dockerfile.wreadsb
@@ -41,7 +41,10 @@ RUN set -x && \
   DISABLE_RTLSDR_ZEROCOPY_WORKAROUND=yes \
   -j "$(nproc)" \
   && \
-  find "/src/readsb" -maxdepth 1 -executable -type f -exec cp -v {} /usr/local/bin/ \; && \
+  cp readsb /usr/local/bin/ && \
+  popd && \
+  pushd /usr/local/bin && \
+  ln -s readsb viewadsb && \
   popd && \
   ldconfig && \
   # readsb: simple tests


### PR DESCRIPTION
this increases the base image size by 17 MB but will save on duplication as this is currently installed in 3 different images separately