### PR TITLE
reduce image sizes by using common wreadsb base image for images that use mlat-client

### DIFF
--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -551,7 +551,7 @@ jobs:
 
   deploy_dump978-full:
     name: Deploy dump978-full to ghcr.io
-    needs: [deploy_soapyrtlsdr]
+    needs: [deploy_wreadsb]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -768,7 +768,7 @@ jobs:
 
   trigger_build_sdr-enthusiasts_docker-dumphfdl:
     name: Trigger deploy of sdr-enthusiasts/docker-dumphfdl
-    needs: [deploy_ghcr_acars-decoder]
+    needs: [deploy_ghcr_acars-decoder-soapy]
     runs-on: ubuntu-latest
     env:
       WORKFLOW_AUTH_TOKEN: ${{ secrets.GH_PAT_MIKENYE }}

--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -602,7 +602,7 @@ jobs:
 
   deploy_wreadsb:
     name: Deploy wreadsb to ghcr.io
-    needs: [deploy_ghcr_rtlsdr]
+    needs: [deploy_ghcr_soapyrtlsdr, deploy_ghcr_mlat_client]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy_wreadsb.yml
+++ b/.github/workflows/deploy_wreadsb.yml
@@ -25,6 +25,7 @@ jobs:
 
   deploy_wreadsb:
     name: Deploy wreadsb to ghcr.io
+    needs: [deploy_ghcr_mlat_client]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -918,7 +918,7 @@ jobs:
   deploy_dump978-full:
     name: Test deploy dump978-full to ghcr.io
     # Define any dependent steps
-    needs: [deploy_soapyrtlsdr]
+    needs: [deploy_wreadsb]
     # Define dockerfile and image tag
     env:
       DOCKERFILE: Dockerfile.dump978-full

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -1012,7 +1012,7 @@ jobs:
   deploy_wreadsb:
     name: Test deploy wreadsb to ghcr.io
     # Define any dependent steps
-    needs: [deploy_ghcr_rtlsdr]
+    needs: [deploy_ghcr_soapyrtlsdr, deploy_ghcr_mlat_client]
     # Define dockerfile and image tag
     env:
       DOCKERFILE: Dockerfile.wreadsb

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,8 +47,6 @@ RUN \
   KEPT_PACKAGES+=(nano) && \
   KEPT_PACKAGES+=(iputils-ping) && \
   KEPT_PACKAGES+=(dnsutils) && \
-  # used by enough images to warrant installing it in common (adds 17 MB to image size)
-  KEPT_PACKAGES+=(python3-minimal) && \
   # install packages
   ## Builder fixes...
   mkdir -p /usr/sbin/ && \

--- a/Dockerfile.dump978-full
+++ b/Dockerfile.dump978-full
@@ -1,4 +1,4 @@
-FROM ghcr.io/sdr-enthusiasts/docker-baseimage:soapyrtlsdr
+FROM ghcr.io/sdr-enthusiasts/docker-baseimage:wreadsb
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile.wreadsb
+++ b/Dockerfile.wreadsb
@@ -1,9 +1,12 @@
+FROM ghcr.io/sdr-enthusiasts/docker-baseimage:mlatclient AS buildimage
+
 FROM ghcr.io/sdr-enthusiasts/docker-baseimage:soapyrtlsdr
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-x", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008,SC2086,DL4006,SC2039
-RUN set -x && \
+RUN \
+  --mount=type=bind,from=buildimage,source=/,target=/buildimage/ \
   TEMP_PACKAGES=() && \
   KEPT_PACKAGES=() && \
   # packages needed to install
@@ -19,6 +22,9 @@ RUN set -x && \
   TEMP_PACKAGES+=(libusb-1.0-0-dev) && \
   TEMP_PACKAGES+=(libzstd-dev) && \
   KEPT_PACKAGES+=(libzstd1) && \
+  # Needed to run the mlat_client:
+  KEPT_PACKAGES+=(python3-minimal) && \
+  KEPT_PACKAGES+=(python3-pkg-resources) && \
   # install packages
   apt-get update && \
   apt-get install -y --no-install-recommends \
@@ -50,8 +56,15 @@ RUN set -x && \
   # readsb: simple tests
   readsb --version && \
   viewadsb --version && \
+  # Get mlat-client
+  tar zxf /buildimage/mlatclient.tgz -C / && \
+  ln -s /usr/local/bin/mlat-client /usr/bin/mlat-client && \
   # Clean up
   apt-get remove -y "${TEMP_PACKAGES[@]}" && \
   apt-get autoremove -q -o APT::Autoremove::RecommendsImportant=0 -o APT::Autoremove::SuggestsImportant=0 -y && \
+  # test mlat-client
+  /usr/bin/mlat-client --help > /dev/null && \
+  # remove pycache introduced by testing mlat-client
+  { find /usr | grep -E "/__pycache__$" | xargs rm -rf || true; } && \
   rm -rf /src/* && \
   bash /scripts/clean-build.sh

--- a/Dockerfile.wreadsb
+++ b/Dockerfile.wreadsb
@@ -1,4 +1,4 @@
-FROM ghcr.io/sdr-enthusiasts/docker-baseimage:rtlsdr
+FROM ghcr.io/sdr-enthusiasts/docker-baseimage:soapyrtlsdr
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
-    base wreadsb on soapyrtlsdr
-    include mlat-client in wreadsb
-    dump978-full: use wreadsb as base

piaware gets this indirectly via dump978-full.
even though piaware has its own mlat-client, the size is reduced due to the common python dependencies.