### PR TITLE
ci: drop redundant hadolint jobs from both deploy workflows

### DIFF
--- a/.github/workflows/deploy_ghcr.yml
+++ b/.github/workflows/deploy_ghcr.yml
@@ -22,20 +22,9 @@ env:
   WORKFLOW_REASON: "triggered via deploy_ghcr.yml in sdr-enthusiasts/docker-baseimage"
 
 jobs:
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   # Basefile
   deploy_ghcr_base:
     name: Base
-    needs: [hadolint]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy_trixie_test.yml
+++ b/.github/workflows/deploy_trixie_test.yml
@@ -22,20 +22,9 @@ env:
   WORKFLOW_REASON: "triggered via deploy_ghcr.yml in sdr-enthusiasts/docker-baseimage"
 
 jobs:
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   # Basefile
   deploy_ghcr_base:
     name: Base
-    needs: [hadolint]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem

Both deploy workflows ran hadolint from unpinned `hadolint/hadolint:latest`, so they silently adopted upstream rule changes. hadolint v2.15.0 (published 2026-07-30T13:39:01Z) extended `DL3025` to fire on `HEALTHCHECK ... CMD` ([#1209](https://github.com/hadolint/hadolint/pull/1209)) and added `DL3064` — the breakage that has been working through this fleet:

`docker-shipfeeder#169`, `docker-adsb-ultrafeeder#278`, `docker-adsbhub#125`, `docker-planefinder#148`, `docker-radarvirtuel#131`, `docker-sdrmap#57`, and eleven more.

This repo's own 16 Dockerfiles happen to be clean at 2.15.1, so nothing was breaking here yet:

```console
$ hadolint --config <shared ruleset> <all 16 Dockerfiles>   # 2.15.1
rc=0
```

**But the exposure here is the worst in the fleet.** `deploy_ghcr_base` and the other image jobs gated on `needs: [hadolint]`, so any future upstream rule change would have **blocked the base image build outright** — and every downstream repo's build is dispatched from `deploy_ghcr.yml`. One new hadolint rule would have stopped the entire fan-out.

## Changes

Removes the `hadolint` job from **both** `deploy_ghcr.yml` and `deploy_trixie_test.yml`, along with the `needs: [hadolint]` references that gated the image jobs. Leaving those references would make the workflows invalid.

The `# Basefile` section comment is deliberately preserved — it documents `deploy_ghcr_base`, not the removed job.

Coverage is unchanged. `check_docker = true`, so `lint.yaml` already lints all 16 Dockerfiles on every PR via pre-commit, against a version pinned through `flake.lock` rather than a floating tag.

## Verification

Both workflows still parse, all jobs intact, and no `needs:` entry points at a job that no longer exists:

```console
$ yq '.jobs | keys' .github/workflows/deploy_ghcr.yml
deploy_ghcr_base  deploy_ghcr_mlat_client  deploy_ghcr_planefence_base
deploy_ghcr_soapy_full  deploy_ghcr_wreadsb  deploy_ghcr_acars-decoder-soapy
deploy_dump978-full  trigger_build_base  trigger_build_acars_soapy
trigger_build_planefence  trigger_build_wreadsb  trigger_build_dump978
monitor_downstream_builds

dangling needs: none
```

```console
$ yq '.jobs | keys' .github/workflows/deploy_trixie_test.yml
deploy_ghcr_base  deploy_ghcr_mlat_client  deploy_ghcr_planefence_base
deploy_ghcr_soapy_full  deploy_ghcr_wreadsb  deploy_ghcr_acars-decoder-soapy
deploy_dump978-full  trigger_build_base  trigger_build_acars_soapy
trigger_build_planefence  trigger_build_wreadsb  trigger_build_dump978

dangling needs: none
```

The downstream dispatch chain is untouched — `trigger_build_*` still depend on their respective image jobs, and `monitor_downstream_builds` still watches every dispatched run including the `tar1090 -> docker-adsb-ultrafeeder` chain.

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped, including `check-github-workflows` (schema validation) and `hadolint` over all 16 Dockerfiles
- No Dockerfile changes in this PR, so no image can be affected
- No hooks bypassed; no `--no-verify`
